### PR TITLE
Handle nested documents in-memory properly.

### DIFF
--- a/lib/has_embedded_document/dsl.rb
+++ b/lib/has_embedded_document/dsl.rb
@@ -81,7 +81,8 @@ module HasEmbeddedDocument
         document = instance_variable_get(:"@__#{name}_cache")
         return document if instance_variable_defined?(:"@__#{name}_cache")
 
-        attributes = reader.call(self)
+        value      = reader.call(self)
+        attributes = value.is_a?(document_class) ? value.attributes : value
         document   = attributes && document_class.new(attributes.dup).readonly!
         instance_variable_set(:"@__#{name}_cache", document)
       end
@@ -116,7 +117,7 @@ module HasEmbeddedDocument
         documents = instance_variable_get(:"@__#{name}_cache")
         return documents if instance_variable_defined?(:"@__#{name}_cache")
 
-        values    = reader.call(self)
+        values    = reader.call(self)&.map { |value| value.is_a?(document_class) ? value.attributes : value }
         documents = values&.map { |attributes| document_class.new(attributes.dup).readonly! }
         instance_variable_set(:"@__#{name}_cache", documents)
       end


### PR DESCRIPTION
When nested documents are constructed in-memory according to the conventions outlined in the docs, you get an error when attempting to access the nested documents (see below). This change mirrors the setter behaviour that already exists by extracting attributes from instances of the document class if the instance is in memory instead of the attributes hash.

Without this change:
```
irb(main):001:0> map = MapData.new(name: 'test')
=> #<MapData:0x0000000107ab7e78 @attributes={"name"=>"test"}>
irb(main):002:0> player = PlayerData.new(name: 'jdude')
=> #<PlayerData:0x0000000108a02158 @attributes={"name"=>"jdude"}>
irb(main):003:0> data = ReplayData.new(factions: ['1'], players: [player], map: map)
=>
#<ReplayData:0x00000001085716e8
...
irb(main):004:0> data.players
/Users/ryantaylor/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/has_embedded_document-c5de29c5d497/lib/has_embedded_document/base.rb:37:in `initialize': undefined method `stringify_keys' for #<PlayerData:0x0000000108941b10 @attributes={"name"=>"jdude"}> (NoMethodError)

      @attributes = attributes.stringify_keys
                              ^^^^^^^^^^^^^^^
irb(main):005:0> data.map
/Users/ryantaylor/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/has_embedded_document-c5de29c5d497/lib/has_embedded_document/base.rb:37:in `initialize': undefined method `stringify_keys' for #<MapData:0x0000000107bb0320 @attributes={"name"=>"test"}> (NoMethodError)

      @attributes = attributes.stringify_keys
                              ^^^^^^^^^^^^
```
With this change:
```
irb(main):001:0> map = MapData.new(name: 'test')
=> #<MapData:0x00000001069d6758 @attributes={"name"=>"test"}>
irb(main):002:0> player = PlayerData.new(name: 'jdude')
=> #<PlayerData:0x0000000106a84b50 @attributes={"name"=>"jdude"}>
irb(main):003:0> data = ReplayData.new(factions: ['1'], players: [player], map: map)
=>
#<ReplayData:0x0000000106ae4870
...
irb(main):004:0> data.players
=> [#<PlayerData:0x00000001067151e0 @attributes={"name"=>"jdude"}>]
irb(main):005:0> data.map
=> #<MapData:0x0000000106004a18 @attributes={"name"=>"test"}>
```